### PR TITLE
Add concurrent health checking in background

### DIFF
--- a/src/main/java/requestManagement/RequestManagerBuilder.java
+++ b/src/main/java/requestManagement/RequestManagerBuilder.java
@@ -1,6 +1,7 @@
 package requestManagement;
 
 import requestManagement.fleetManager.FleetManager;
+import requestManagement.fleetManager.healthCheck.HealthCheck;
 import requestManagement.loadBalancer.LoadBalancer;
 
 public class RequestManagerBuilder {
@@ -9,6 +10,7 @@ public class RequestManagerBuilder {
 
     private LoadBalancer loadBalancer = null;
     private FleetManager fleetManager = null;
+    private HealthCheck healthCheck;
 
     protected RequestManagerBuilder() {
 
@@ -30,6 +32,11 @@ public class RequestManagerBuilder {
     public RequestManagerBuilder withFleetManager(FleetManager fleetManager) {
         this.setFleetManager(fleetManager);
 
+        return this;
+    }
+
+    public RequestManagerBuilder withHealthChecker(HealthCheck healthCheck) {
+        this.healthCheck = healthCheck;
         return this;
     }
 
@@ -61,4 +68,7 @@ public class RequestManagerBuilder {
         return fleetManager;
     }
 
+    HealthCheck getHealthCheck() {
+        return healthCheck;
+    }
 }

--- a/src/main/java/requestManagement/RequestManagerImpl.java
+++ b/src/main/java/requestManagement/RequestManagerImpl.java
@@ -3,6 +3,8 @@ package requestManagement;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import requestManagement.fleetManager.FleetManager;
+import requestManagement.fleetManager.healthCheck.HealthCheck;
+import requestManagement.fleetManager.healthCheck.HealthCheckPingingStrategy;
 import requestManagement.loadBalancer.LoadBalancer;
 
 public class RequestManagerImpl implements RequestManager {
@@ -10,11 +12,13 @@ public class RequestManagerImpl implements RequestManager {
     private Dispatcher dispatcher = null;
     private LoadBalancer loadBalancer = null;
     private FleetManager fleetManager = null;
+    private HealthCheck healthCheck = null;
 
     RequestManagerImpl(RequestManagerBuilder builder) {
         dispatcher = builder.getDispatcher();
         loadBalancer = builder.getLoadBalancer();
         fleetManager = builder.getFleetManager();
+        healthCheck = builder.getHealthCheck();
     }
 
     @Override
@@ -43,5 +47,7 @@ public class RequestManagerImpl implements RequestManager {
     @Override
     public void initialiseFleet() {
         /* Should initialise the fleet here eventually. */
+        long refreshInterval = 5000L;
+        healthCheck.execute(new HealthCheckPingingStrategy(), refreshInterval);
     }
 }

--- a/src/main/java/requestManagement/fleetManager/healthCheck/HealthCheck.java
+++ b/src/main/java/requestManagement/fleetManager/healthCheck/HealthCheck.java
@@ -10,6 +10,7 @@ public interface HealthCheck {
     /**
      * Execute the health check strategy and monitor fleet health
      * @param healthCheckStrategy The strategy to check the fleet health
+     * @param refreshInterval The duration the thread sleeps in between each health check in milliseconds
      */
-    void execute(HealthCheckStrategy healthCheckStrategy);
+    void execute(HealthCheckStrategy healthCheckStrategy, long refreshInterval);
 }

--- a/src/main/java/requestManagement/fleetManager/healthCheck/HealthCheckImplementation.java
+++ b/src/main/java/requestManagement/fleetManager/healthCheck/HealthCheckImplementation.java
@@ -25,6 +25,7 @@ public class HealthCheckImplementation implements HealthCheck {
             try {
                 Thread.sleep(refreshInterval);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 e.printStackTrace();
                 break;
             }

--- a/src/main/java/requestManagement/fleetManager/healthCheck/HealthCheckImplementation.java
+++ b/src/main/java/requestManagement/fleetManager/healthCheck/HealthCheckImplementation.java
@@ -2,18 +2,32 @@ package requestManagement.fleetManager.healthCheck;
 
 import requestManagement.fleetManager.FleetManager;
 
-public class HealthCheckImplementation {
+public class HealthCheckImplementation implements HealthCheck {
     private FleetManager fleetManager;
 
     public HealthCheckImplementation(FleetManager fleetManager) {
         this.fleetManager = fleetManager;
     }
 
-    public void execute(HealthCheckStrategy strategy) {
-        strategy.runHealthCheck(this.fleetManager);
+    public void execute(HealthCheckStrategy strategy, long refreshInterval) {
+        Runnable task = () -> performHealthCheck(strategy, refreshInterval);
+        new Thread(task).start();
+    }
 
-        if (fleetManager.getNumActiveHosts() < 2) {
-            // Add new host(s)
+    private void performHealthCheck(HealthCheckStrategy strategy, long refreshInterval) {
+        while (true) {
+            strategy.runHealthCheck(this.fleetManager);
+
+            if (fleetManager.getNumActiveHosts() < 2) {
+                // Add new host(s)
+            }
+
+            try {
+                Thread.sleep(refreshInterval);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                break;
+            }
         }
     }
 }

--- a/src/main/test/TestRequestManagement.java
+++ b/src/main/test/TestRequestManagement.java
@@ -4,6 +4,8 @@ import requestManagement.Dispatcher;
 import requestManagement.RequestManager;
 import requestManagement.Service;
 import requestManagement.fleetManager.FleetManager;
+import requestManagement.fleetManager.healthCheck.HealthCheck;
+import requestManagement.fleetManager.healthCheck.HealthCheckImplementation;
 import requestManagement.loadBalancer.LoadBalancer;
 
 import java.util.ArrayList;
@@ -61,12 +63,14 @@ class TestRequestManagement {
         Dispatcher dispatcher = new Dispatcher(services);
         LoadBalancer loadBalancer = null;
         FleetManager fleetManager = FleetManager.getInstance();
+        HealthCheck healthCheck = new HealthCheckImplementation(fleetManager);
 
         /* Test that the request manager builds successfully with valid member variables */
         RequestManager requestManager = RequestManager.getBuilder()
                 .withFleetManager(fleetManager)
                 .withLoadBalancer(loadBalancer)
                 .withDispatcher(dispatcher)
+                .withHealthChecker(healthCheck)
                 .build();
 
         /* TODO: Should eventually raise argument exceptions when invalid dependency classes are passed and test such cases */


### PR DESCRIPTION
Added health checking to run in a background thread on initializeFleet() in the request manager. I didn't add any tests as testing multiple threads is difficult, and I don't think it's worth the time investment for this project. If you want to see the health checking running in a background thread, try this test

```
    @Test
    void shouldRunHealthCheckInBackground() {
        FleetManager fleetManager = Mockito.mock(FleetManager.class);
        HealthCheck healthCheck = new HealthCheckImplementation(fleetManager);

        RequestManager requestManager = RequestManager.getBuilder()
                .withFleetManager(fleetManager)
                .withLoadBalancer(null)
                .withDispatcher(null)
                .withHealthChecker(healthCheck)
                .build();

        when(fleetManager.getHosts()).thenReturn(Collections.singletonList(new Host.HostBuilder("127.0.0.1").build()));
        when(fleetManager.getNumActiveHosts()).thenReturn(1);
        requestManager.initialiseFleet();

        try {
            Thread.sleep(100000L);
        } catch (InterruptedException e) {
            e.printStackTrace();
        }
    }
```