### PR TITLE
Support for GET Requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,11 +34,6 @@
             <version>20090211</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>4.4.6</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <version>RELEASE</version>

--- a/src/main/java/requestManagement/RequestManager.java
+++ b/src/main/java/requestManagement/RequestManager.java
@@ -1,6 +1,5 @@
 package requestManagement;
 
-
 import org.apache.http.HttpResponse;
 import requests.HttpRequest;
 

--- a/src/main/java/requestManagement/RequestManager.java
+++ b/src/main/java/requestManagement/RequestManager.java
@@ -5,7 +5,7 @@ import org.apache.http.HttpResponse;
 import requests.HttpRequest;
 
 /**
- * Handles a SimpleHttpRequest.
+ * Handles a HttpRequest.
  *
  * An implementation of this class will handle LoadBalancing of requests across a preconfigured fleet. It will also
  * handle Fleet Management from an end user perspective.

--- a/src/main/java/requestManagement/fleetManager/HealthCheckImplementation.java
+++ b/src/main/java/requestManagement/fleetManager/HealthCheckImplementation.java
@@ -4,12 +4,12 @@ import requestManagement.fleetManager.hosts.Host;
 
 import java.util.List;
 
-public class HeathCheckImplementation implements HealthCheck {
+public class HealthCheckImplementation implements HealthCheck {
 
     private FleetManager fleetManager;
     private List<Host> allHosts;
 
-    public HeathCheckImplementation() {}
+    public HealthCheckImplementation() {}
 
     @Override
     public void runHealthCheck() {

--- a/src/main/java/requestManagement/loadBalancer/LbClientSideRandom.java
+++ b/src/main/java/requestManagement/loadBalancer/LbClientSideRandom.java
@@ -1,7 +1,7 @@
 package requestManagement.loadBalancer;
 
 import requestManagement.fleetManager.FleetManager;
-import requestManagement.fleetManager.hosts.ActiveHost;
+import requestManagement.fleetManager.hosts.Host;
 
 public class LbClientSideRandom extends LbStrategy {
 
@@ -10,8 +10,8 @@ public class LbClientSideRandom extends LbStrategy {
     }
 
     @Override
-    public ActiveHost getNextHost() {
-        return new ActiveHost();
+    public Host getNextHost() {
+        return fleetManager.getHosts().get(0);
     }
 
 }

--- a/src/main/java/requestManagement/loadBalancer/LbClientSideRandom.java
+++ b/src/main/java/requestManagement/loadBalancer/LbClientSideRandom.java
@@ -13,5 +13,4 @@ public class LbClientSideRandom extends LbStrategy {
     public Host getNextHost() {
         return fleetManager.getHosts().get(0);
     }
-
 }

--- a/src/main/java/requestManagement/loadBalancer/LbRoundRobin.java
+++ b/src/main/java/requestManagement/loadBalancer/LbRoundRobin.java
@@ -1,7 +1,7 @@
 package requestManagement.loadBalancer;
 
 import requestManagement.fleetManager.FleetManager;
-import requestManagement.fleetManager.hosts.ActiveHost;
+import requestManagement.fleetManager.hosts.Host;
 
 public class LbRoundRobin extends LbStrategy {
 
@@ -10,7 +10,7 @@ public class LbRoundRobin extends LbStrategy {
     }
 
     @Override
-    public ActiveHost getNextHost() {
-        return new ActiveHost();
+    public Host getNextHost() {
+        return null;//new Host();
     }
 }

--- a/src/main/java/requestManagement/loadBalancer/LbStrategy.java
+++ b/src/main/java/requestManagement/loadBalancer/LbStrategy.java
@@ -1,11 +1,14 @@
 package requestManagement.loadBalancer;
 
 import requestManagement.fleetManager.FleetManager;
-import requestManagement.fleetManager.hosts.ActiveHost;
+import requestManagement.fleetManager.hosts.Host;
 
 public abstract class LbStrategy {
+    protected FleetManager fleetManager;
 
-    public LbStrategy(FleetManager fleetManager) {}
+    public LbStrategy(FleetManager fleetManager) {
+        this.fleetManager = fleetManager;
+    }
 
-    public abstract ActiveHost getNextHost();
+    public abstract Host getNextHost();
 }

--- a/src/main/java/requestManagement/loadBalancer/LoadBalancer.java
+++ b/src/main/java/requestManagement/loadBalancer/LoadBalancer.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 public interface LoadBalancer {
 
     HttpResponse executeRequest(HttpRequest request) throws IOException;
+
     static LoadBalancerBuilder getBuilder() {
         return new LoadBalancerBuilder();
     }

--- a/src/main/java/requestManagement/loadBalancer/LoadBalancer.java
+++ b/src/main/java/requestManagement/loadBalancer/LoadBalancer.java
@@ -3,9 +3,11 @@ package requestManagement.loadBalancer;
 import requests.HttpRequest;
 import responses.HttpResponse;
 
+import java.io.IOException;
+
 public interface LoadBalancer {
 
-    HttpResponse executeRequest(HttpRequest request);
+    HttpResponse executeRequest(HttpRequest request) throws IOException;
     static LoadBalancerBuilder getBuilder() {
         return new LoadBalancerBuilder();
     }

--- a/src/main/java/requestManagement/loadBalancer/LoadBalancerImpl.java
+++ b/src/main/java/requestManagement/loadBalancer/LoadBalancerImpl.java
@@ -38,7 +38,6 @@ public class LoadBalancerImpl implements LoadBalancer {
             facadeResponse = responseFactory.generateResponse(response);
         } finally {
             httpClient.close();
-
             // TODO: Decrement active connections for host.
         }
         return facadeResponse;

--- a/src/main/java/requests/ExecutableRequestFactory.java
+++ b/src/main/java/requests/ExecutableRequestFactory.java
@@ -1,11 +1,39 @@
 package requests;
 
 import org.apache.http.client.methods.HttpRequestBase;
-import requestManagement.fleetManager.hosts.ActiveHost;
+import requestManagement.fleetManager.hosts.Host;
+import requests.generators.GetRequestGenerator;
+import requests.generators.PostRequestGenerator;
+import requests.generators.PutRequestGenerator;
+import requests.generators.RequestGenerator;
 
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * Factory class that builds Executable HTTP Requests from the Facade HttpRequest object that we have created.
+ */
 public class ExecutableRequestFactory {
 
-    public HttpRequestBase getExecutableRequest(HttpRequest request, ActiveHost host) {
-        return null;
+    Map<String, RequestGenerator> requestGenerators;
+
+    public ExecutableRequestFactory() {
+        this.requestGenerators = initialiseGenerators();
+    }
+
+    public HttpRequestBase getExecutableRequest(HttpRequest request, Host host) {
+
+        return requestGenerators.get(request.getMethod()).generateRequest(request, host);
+    }
+
+    private HashMap<String, RequestGenerator> initialiseGenerators() {
+        HashMap<String, RequestGenerator> generators = new HashMap<>();
+
+        generators.put("GET", new GetRequestGenerator());
+        generators.put("POST", new PostRequestGenerator());
+        generators.put("PUT", new PutRequestGenerator());
+
+        return generators;
     }
 }

--- a/src/main/java/requests/ExecutableRequestFactory.java
+++ b/src/main/java/requests/ExecutableRequestFactory.java
@@ -10,7 +10,6 @@ import requests.generators.RequestGenerator;
 import java.util.HashMap;
 import java.util.Map;
 
-
 /**
  * Factory class that builds Executable HTTP Requests from the Facade HttpRequest object that we have created.
  */
@@ -23,12 +22,11 @@ public class ExecutableRequestFactory {
     }
 
     public HttpRequestBase getExecutableRequest(HttpRequest request, Host host) {
-
         return requestGenerators.get(request.getMethod()).generateRequest(request, host);
     }
 
-    private HashMap<String, RequestGenerator> initialiseGenerators() {
-        HashMap<String, RequestGenerator> generators = new HashMap<>();
+    private Map<String, RequestGenerator> initialiseGenerators() {
+        Map<String, RequestGenerator> generators = new HashMap<>();
 
         generators.put("GET", new GetRequestGenerator());
         generators.put("POST", new PostRequestGenerator());

--- a/src/main/java/requests/HttpRequest.java
+++ b/src/main/java/requests/HttpRequest.java
@@ -3,7 +3,7 @@ package requests;
 import org.json.JSONObject;
 
 /**
- * Interface for HTTP Requests used by the Load Balancing framework.
+ * Facade object for HTTP Requests used by the Load Balancing framework.
  */
 public class HttpRequest {
 
@@ -11,7 +11,13 @@ public class HttpRequest {
     private JSONObject json;
     private String uri;
 
-    HttpRequest(HttpRequestBuilder builder) {
+    /**
+     * This constructor is protected level access in order to allow adaptor classes that subclass the HttpRequest class
+     * to be instantiated using a standard builder.
+     *
+     * @param builder Object builder.
+     */
+    protected HttpRequest(HttpRequestBuilder builder) {
         this.method = builder.getMethod();
         this.json = builder.getJson();
         this.uri = builder.getUri();
@@ -29,7 +35,7 @@ public class HttpRequest {
         return uri;
     }
 
-    /* More members, i.e. Client IP Insertion, Cookie Insertion, etc.*/
+    /* More members, i.e. Client IP Insertion, Cookie Insertion, etc that would be private and part of the facade. */
 
     public static HttpRequestBuilder getBuilder() {
         return new HttpRequestBuilder();

--- a/src/main/java/requests/HttpRequest.java
+++ b/src/main/java/requests/HttpRequest.java
@@ -8,7 +8,7 @@ import org.json.JSONObject;
 public class HttpRequest {
 
     private String method;
-    private JSONObject json;
+    private JSONObject body;
     private String uri;
 
     /**
@@ -19,7 +19,7 @@ public class HttpRequest {
      */
     protected HttpRequest(HttpRequestBuilder builder) {
         this.method = builder.getMethod();
-        this.json = builder.getJson();
+        this.body = builder.getBody();
         this.uri = builder.getUri();
     }
 
@@ -27,8 +27,8 @@ public class HttpRequest {
         return method;
     }
 
-    public JSONObject getParams() {
-        return json;
+    public JSONObject getBody() {
+        return body;
     }
 
     public String getUri() {

--- a/src/main/java/requests/HttpRequestBuilder.java
+++ b/src/main/java/requests/HttpRequestBuilder.java
@@ -36,6 +36,7 @@ public class HttpRequestBuilder {
 
     public HttpRequestBuilder withMethod(String method) {
         setMethod(method);
+
         return this;
     }
 

--- a/src/main/java/requests/HttpRequestBuilder.java
+++ b/src/main/java/requests/HttpRequestBuilder.java
@@ -7,15 +7,15 @@ public class HttpRequestBuilder {
     HttpRequestBuilder() { }
 
     private String method;
-    private JSONObject json;
+    private JSONObject body;
     private String uri;
 
     public void setMethod(String method) {
         this.method = method;
     }
 
-    public void setJson(JSONObject json) {
-        this.json = json;
+    public void setBody(JSONObject json) {
+        this.body = json;
     }
 
     public void setUri(String uri) {
@@ -26,8 +26,8 @@ public class HttpRequestBuilder {
         return this.method;
     }
 
-    public JSONObject getJson() {
-        return this.json;
+    public JSONObject getBody() {
+        return this.body;
     }
 
     public String getUri() {
@@ -40,7 +40,7 @@ public class HttpRequestBuilder {
     }
 
     public HttpRequestBuilder withJson(JSONObject json) {
-        setJson(json);
+        setBody(json);
 
         return this;
     }

--- a/src/main/java/requests/adapters/RequestXmlAdapter.java
+++ b/src/main/java/requests/adapters/RequestXmlAdapter.java
@@ -1,7 +1,13 @@
 package requests.adapters;
 
+import requests.HttpRequest;
+import requests.HttpRequestBuilder;
+
 /**
- * Converts XML parameters to JSON.
+ * An example adaptor for the HttpRequest. Would convert XML request body to JSON request body if actually implemented.
  */
-public class RequestXmlAdapter {
+public class RequestXmlAdapter extends HttpRequest {
+    RequestXmlAdapter(HttpRequestBuilder builder) {
+        super(builder);
+    }
 }

--- a/src/main/java/requests/generators/GetRequestGenerator.java
+++ b/src/main/java/requests/generators/GetRequestGenerator.java
@@ -1,0 +1,33 @@
+package requests.generators;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import requestManagement.fleetManager.hosts.Host;
+import requests.HttpRequest;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class GetRequestGenerator implements RequestGenerator {
+
+    @Override
+    public HttpRequestBase generateRequest(HttpRequest request, Host host) {
+        String endUri = null;
+        try {
+            URI originalUri = new URI(request.getUri());
+
+            StringBuilder uriBuilder = new StringBuilder();
+            uriBuilder.append("https://");
+            uriBuilder.append(host.getDns());
+            if(originalUri.getPath() != null) uriBuilder.append(originalUri.getPath());
+            if(originalUri.getQuery() != null) uriBuilder.append("?" + originalUri.getQuery());
+
+            endUri = uriBuilder.toString();
+
+        } catch(URISyntaxException ex) {
+            // TODO: Log this
+        }
+
+        return new HttpGet(endUri);
+    }
+}

--- a/src/main/java/requests/generators/GetRequestGenerator.java
+++ b/src/main/java/requests/generators/GetRequestGenerator.java
@@ -23,9 +23,8 @@ public class GetRequestGenerator implements RequestGenerator {
             if(originalUri.getQuery() != null) uriBuilder.append("?" + originalUri.getQuery());
 
             endUri = uriBuilder.toString();
-
-        } catch(URISyntaxException ex) {
-            // TODO: Log this
+        } catch (URISyntaxException ex) {
+            ex.printStackTrace();
         }
 
         return new HttpGet(endUri);

--- a/src/main/java/requests/generators/PostRequestGenerator.java
+++ b/src/main/java/requests/generators/PostRequestGenerator.java
@@ -1,0 +1,13 @@
+package requests.generators;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import requestManagement.fleetManager.hosts.Host;
+import requests.HttpRequest;
+
+public class PostRequestGenerator implements RequestGenerator {
+
+    @Override
+    public HttpRequestBase generateRequest(HttpRequest request, Host host) {
+        return null;
+    }
+}

--- a/src/main/java/requests/generators/PutRequestGenerator.java
+++ b/src/main/java/requests/generators/PutRequestGenerator.java
@@ -1,0 +1,14 @@
+package requests.generators;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import requestManagement.fleetManager.hosts.Host;
+import requests.HttpRequest;
+
+public class PutRequestGenerator implements RequestGenerator {
+
+    @Override
+    public HttpRequestBase generateRequest(HttpRequest request, Host host) {
+        return null;
+    }
+
+}

--- a/src/main/java/requests/generators/PutRequestGenerator.java
+++ b/src/main/java/requests/generators/PutRequestGenerator.java
@@ -10,5 +10,4 @@ public class PutRequestGenerator implements RequestGenerator {
     public HttpRequestBase generateRequest(HttpRequest request, Host host) {
         return null;
     }
-
 }

--- a/src/main/java/requests/generators/RequestGenerator.java
+++ b/src/main/java/requests/generators/RequestGenerator.java
@@ -1,0 +1,10 @@
+package requests.generators;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import requestManagement.fleetManager.hosts.Host;
+import requests.HttpRequest;
+
+@FunctionalInterface
+public interface RequestGenerator {
+    HttpRequestBase generateRequest(HttpRequest request, Host host);
+}

--- a/src/main/java/responses/HttpResponse.java
+++ b/src/main/java/responses/HttpResponse.java
@@ -1,7 +1,45 @@
 package responses;
 
-/**
- * Created by Robbi on 20/10/2017.
- */
-public interface HttpResponse {
+import org.json.JSONObject;
+
+import java.util.Map;
+
+public class HttpResponse {
+
+    private Map<String, String> headers;
+    private JSONObject body;
+    private String status;
+    private int statusCode;
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public void setBody(JSONObject body) {
+        this.body = body;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    public JSONObject getBody() {
+        return this.body;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    public int getStatusCode() {
+        return this.statusCode;
+    }
 }

--- a/src/main/java/responses/ResponseFactory.java
+++ b/src/main/java/responses/ResponseFactory.java
@@ -1,10 +1,37 @@
 package responses;
 
+import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ResponseFactory {
 
     public HttpResponse generateResponse(CloseableHttpResponse response) {
-        return null;
+        HttpResponse facadeResponse = new HttpResponse();
+        JSONObject json = null;
+        Map<String, String> headers = new HashMap<>();
+
+        facadeResponse.setStatusCode(response.getStatusLine().getStatusCode());
+        facadeResponse.setStatus(response.getStatusLine().getReasonPhrase());
+
+        Arrays.asList(response.getAllHeaders()).forEach(h -> headers.put(h.getName(), h.getValue()));
+        facadeResponse.setHeaders(headers);
+
+        try {
+            json = new JSONObject(EntityUtils.toString(response.getEntity()));
+
+        } catch (IOException | JSONException ex) {
+            ex.printStackTrace();
+        }
+
+        facadeResponse.setBody(json);
+        return facadeResponse;
     }
 }

--- a/src/main/java/responses/SimpleHttpResponse.java
+++ b/src/main/java/responses/SimpleHttpResponse.java
@@ -1,7 +1,0 @@
-package responses;
-
-/**
- * Created by Robbi on 20/10/2017.
- */
-public class SimpleHttpResponse {
-}

--- a/src/main/java/responses/adapters/ResponseXmlAdapter.java
+++ b/src/main/java/responses/adapters/ResponseXmlAdapter.java
@@ -1,6 +1,0 @@
-package responses.adapters;
-
-public class ResponseXmlAdapter {
-
-    
-}

--- a/src/main/test/integ/HttpRequests.java
+++ b/src/main/test/integ/HttpRequests.java
@@ -63,7 +63,7 @@ class HttpRequests {
 
         try {
             response = loadBalancer.executeRequest(request);
-        } catch( IOException ex) {
+        } catch (IOException ex) {
             ex.printStackTrace();
         }
 

--- a/src/main/test/integ/HttpRequests.java
+++ b/src/main/test/integ/HttpRequests.java
@@ -1,0 +1,72 @@
+package integ;
+
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import requests.HttpRequest;
+import responses.HttpResponse;
+import requestManagement.fleetManager.FleetManager;
+import requestManagement.fleetManager.hosts.Host;
+import requestManagement.loadBalancer.LbClientSideRandom;
+import requestManagement.loadBalancer.LoadBalancer;
+
+import java.io.IOException;
+
+/**
+ * Testing for load balancer request dispatch. Uses the httpbin.org website for testing requests/responses.
+ */
+class HttpRequests {
+
+    private LoadBalancer loadBalancer;
+    
+    @BeforeEach
+    void setUp() {
+        FleetManager fleetManager = FleetManager.getInstance();
+        Host testHost = new Host.HostBuilder("192.168.1.1")
+                .withDns("httpbin.org")
+                .withState("active")
+                .build();
+
+        fleetManager.addHost(testHost);
+
+        loadBalancer = LoadBalancer.getBuilder()
+                .withFleetManager(fleetManager)
+                .withLoadBalancingStrategy(new LbClientSideRandom(fleetManager))
+                .build();
+
+    }
+
+
+    @Test
+    void shouldReturn200Success() throws IOException {
+        HttpResponse response = null;
+
+        HttpRequest request = HttpRequest.getBuilder()
+                .withUri("https://my-random-example-middleware-host.com/get")
+                .withMethod("GET")
+                .build();
+
+        response = loadBalancer.executeRequest(request);
+
+        assert response.getStatus().equals("OK");
+        assert response.getStatusCode() == 200;
+    }
+
+    @Test
+    void shouldContainCorrectJsonResponseMappedFromQueryString() throws JSONException {
+        HttpResponse response = null;
+
+        HttpRequest request = HttpRequest.getBuilder()
+                .withUri("https://my-other-super-random-example-middleware-host.com/get?sample_arg=1")
+                .withMethod("GET")
+                .build();
+
+        try {
+            response = loadBalancer.executeRequest(request);
+        } catch( IOException ex) {
+            ex.printStackTrace();
+        }
+
+        assert response.getBody().getJSONObject("args").getInt("sample_arg") == 1;
+    }
+}

--- a/src/main/test/integ/HttpRequests.java
+++ b/src/main/test/integ/HttpRequests.java
@@ -36,7 +36,6 @@ class HttpRequests {
 
     }
 
-
     @Test
     void shouldReturn200Success() throws IOException {
         HttpResponse response = null;

--- a/src/main/test/unit/LoadBalancerTest.java
+++ b/src/main/test/unit/LoadBalancerTest.java
@@ -1,3 +1,5 @@
+package unit;
+
 import requestManagement.fleetManager.FleetManager;
 import requestManagement.loadBalancer.LbRoundRobin;
 import requestManagement.loadBalancer.LbStrategy;

--- a/src/main/test/unit/TestFleetManagement.java
+++ b/src/main/test/unit/TestFleetManagement.java
@@ -1,5 +1,6 @@
+package unit;
+
 import org.junit.jupiter.api.*;
-import org.mockito.*;
 import requestManagement.fleetManager.FleetManager;
 import requestManagement.fleetManager.hosts.Host;
 

--- a/src/main/test/unit/TestRequestManagement.java
+++ b/src/main/test/unit/TestRequestManagement.java
@@ -1,3 +1,5 @@
+package unit;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import requestManagement.Dispatcher;


### PR DESCRIPTION
I've added support for actually making get requests. The classes/framework for POST and PUT requests is there also, but I have not implemented them. 

A facade HttpRequest has been implemented that includes the method, URI and JSON body in the public API for the class. More complicated aspects such as certain headers (like source IP) that could be used to route requests will be part of the protected level access API, meaning that builders and adapters can make use of these features, but new/inexperienced users will not need to access them. 

Factories have been created to handle mapping requests and responses to the requests/responses used by the Apache HTTP Client. 

Also added some integration tests.