### PR TITLE
Support for intercepting services to control HTTP response

### DIFF
--- a/src/main/java/requestManagement/Context.java
+++ b/src/main/java/requestManagement/Context.java
@@ -1,5 +1,7 @@
 package requestManagement;
 
+import responses.HttpResponse;
+
 /**
  * This class encapsulates events that are dispatched to interceptor services..
  *
@@ -10,6 +12,7 @@ package requestManagement;
 public class Context <T> {
 
     private T event;
+    private HttpResponse response = null;
 
     public void setEvent(T event) {
         this.event = event;
@@ -19,5 +22,14 @@ public class Context <T> {
         return event;
     }
 
+    /** Used if a subscribed service has any reason to override the response that would normally be return to the client. */
+    public void setResponse(HttpResponse response) {
+        this.response = response;
+    }
+
+    public HttpResponse getResponse() {
+        return response;
+    }
     /* TODO: Will eventually be other methods here to allow sharing of *standard* information between interceptor services and control framework. */
+
 }

--- a/src/main/java/requestManagement/RequestManagerImpl.java
+++ b/src/main/java/requestManagement/RequestManagerImpl.java
@@ -31,7 +31,7 @@ public class RequestManagerImpl implements RequestManager {
         requestContext.setEvent(request);
         dispatcher.dispatchIncomingRequest(requestContext);
 
-        if(requestContext.getResponse() != null) {
+        if (requestContext.getResponse() != null) {
             return requestContext.getResponse();
         }
 
@@ -46,7 +46,7 @@ public class RequestManagerImpl implements RequestManager {
 
         dispatcher.dispatchOutgoingResponse(responseContext);
 
-        if(responseContext.getResponse() != null) {
+        if (responseContext.getResponse() != null) {
             return responseContext.getResponse();
         }
 

--- a/src/main/java/requestManagement/RequestManagerImpl.java
+++ b/src/main/java/requestManagement/RequestManagerImpl.java
@@ -25,16 +25,15 @@ public class RequestManagerImpl implements RequestManager {
 
     @Override
     public HttpResponse handleRequest(HttpRequest request) {
-
-        /* Dispatch incoming request event to all subscribed services. */
+        HttpResponse response = null;
 
         Context<HttpRequest> requestContext = new Context<>();
         requestContext.setEvent(request);
         dispatcher.dispatchIncomingRequest(requestContext);
 
-        /* Actually forward the request. This is where the Load Balancer would be called.*/
-
-        HttpResponse response = null;
+        if(requestContext.getResponse() != null) {
+            return requestContext.getResponse();
+        }
 
         try {
             response = loadBalancer.executeRequest(request);
@@ -44,9 +43,12 @@ public class RequestManagerImpl implements RequestManager {
 
         Context<HttpResponse> responseContext = new Context<>();
         responseContext.setEvent(response);
-        
-        /* Dispatch outgoing response to all subscribed services */
+
         dispatcher.dispatchOutgoingResponse(responseContext);
+
+        if(responseContext.getResponse() != null) {
+            return responseContext.getResponse();
+        }
 
         return response;
     }


### PR DESCRIPTION
Added support for intercepting services to control the HTTP response that is returned. This is done by adding a response as a member variable of the context object that can be set by intercepting services. The RequestManager (the medium through which the interceptor architecture pattern has been implemented) will then check to see if a response has been defined after it dispatches any event. If the response has been defined then it will be returned to the client.